### PR TITLE
Fix issue with :global styles not being exported

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,6 +9,10 @@ function traverse(rules) {
         typeof rule.options.modules.getLocalIdent === 'function'
       ) {
         let nextGetLocalIdent = rule.options.modules.getLocalIdent;
+        rule.options.modules.mode = 'local';
+        rule.options.modules.auto = true;
+        rule.options.modules.exportGlobals = true;
+        rule.options.modules.exportOnlyLocals = false;
         rule.options.modules.getLocalIdent = (context, _, exportName, options) => {
           if (context.resourcePath.includes(LINARIA_EXTENSION)) {
             return exportName;


### PR DESCRIPTION
Fix for this issue found during integrating with NextJS - https://github.com/callstack/linaria/issues/589#issuecomment-858625050

