### PR TITLE
Replace peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "dependencies": {},
   "devDependencies": {},
   "peerDependencies": {
-    "linaria": "*"
+    "@linaria/webpack-loader": "*"
   },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"


### PR DESCRIPTION
Replace peer dependency with the @linaria/webpack-loader due to the splitting linaria packages to @linaria scope from v3.0