### PR TITLE
Added support for configuring the exclude rule of the webpack config

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,31 @@ module.exports = withLinaria({
   },
 });
 ```
+### Transpiling Linaria files from node_modules
+By default this package will ignore all of node_modules by default.
 
+If you have a package inside of node_modules with Linaria files that you would like to transpile, you need to add the package to the rules array of the Linaria config
+
+Keep in mind that this overrides Linaria's default rules, so you will want to make sure you add 
+```js
+// next.config.js
+const withLinaria = require('next-linaria');
+module.exports = withLinaria({
+  linaria: {
+    rules: [
+      {
+        action: require('@linaria/shaker').default,
+      },
+      {
+        test: /node_modules[\/\\](?!\@example\\package)/,
+        action: 'ignore',
+      },
+    ],
+    /* other linaria options here */
+  },
+});
+```
+This can be used in combination with https://github.com/martpie/next-transpile-modules to transpile the rest of the package if necessary
 ## License
 
 The MIT License (MIT)

--- a/index.js
+++ b/index.js
@@ -30,6 +30,16 @@ function traverse(rules) {
   }
 }
 
+function getLinariaIgnore(linariaConfig) {
+  if (linariaConfig && linariaConfig.rules) {
+    const ignoreRule = linariaConfig.rules.find(rule =>
+      rule.action && rule.action === 'ignore' && rule.test
+    );
+    return ignoreRule && ignoreRule.test
+  }
+  return null;
+}
+
 module.exports = (nextConfig = {}) => {
   return {
     ...nextConfig,
@@ -37,7 +47,7 @@ module.exports = (nextConfig = {}) => {
       traverse(config.module.rules);
       config.module.rules.push({
         test: /\.(tsx|ts|js|mjs|jsx)$/,
-        exclude: /node_modules/,
+        exclude: getLinariaIgnore(nextConfig.linaria) || /node_modules/,
         use: [
           {
             loader: require.resolve('@linaria/webpack-loader'),


### PR DESCRIPTION
I've been struggling for days to get Next JS to play nice with untranspiled Linaria files in a component library that we're building, until I finally came across this discussion in the Linaria repo https://github.com/callstack/linaria/issues/178#issuecomment-761773489

The last missing piece here, then, is being able to configure the exclude of the linaria webpack rule. Since Linaria has it's own array of rules, I thought this approach could be useful for allowing to override both in one go.

I've tested it with https://github.com/martpie/next-transpile-modules, which works just fine!

Let me know what you think!